### PR TITLE
feat: add schema caching with --cache-dir

### DIFF
--- a/src/builder.go
+++ b/src/builder.go
@@ -41,7 +41,7 @@ type Test struct {
 	ignoredLines                             []string
 }
 
-func (test *Test) Run(theChart *chart.Chart, installAction *action.Install, rootPath string, ignorePatterns []string, schema *cue.Value) error {
+func (test *Test) Run(theChart *chart.Chart, installAction *action.Install, rootPath string, ignorePatterns []string, schema *cue.Value, cacheDir string) error {
 	testValuesPath := filepath.Join(rootPath, test.name, "values.yaml")
 	testValues, err := loadValuesFile(testValuesPath)
 	if err != nil {
@@ -164,7 +164,7 @@ func (test *Test) Run(theChart *chart.Chart, installAction *action.Install, root
 	}
 
 	// Validate
-	err = validateManifest(test, release.Manifest)
+	err = validateManifest(test, release.Manifest, cacheDir)
 	if err != nil {
 		return fmt.Errorf("validating manifest: %w", err)
 	}
@@ -510,6 +510,7 @@ type RunOptions struct {
 	IgnorePatterns []string
 	Schema         *cue.Value
 	Concurrency    int
+	CacheDir       string
 	HelmOptions
 }
 
@@ -580,7 +581,7 @@ func (suite TestSuite) Run(opts RunOptions) error {
 					theChart.Metadata.AppVersion = appVersion
 				}
 
-				if err := test.Run(theChart, installAction, opts.RootFS, opts.IgnorePatterns, opts.Schema); err != nil {
+				if err := test.Run(theChart, installAction, opts.RootFS, opts.IgnorePatterns, opts.Schema, opts.CacheDir); err != nil {
 					e <- fmt.Errorf("running test %s: %w", test.name, err)
 					return
 				}

--- a/src/main.go
+++ b/src/main.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"os"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
@@ -28,6 +29,17 @@ var (
 	normalize     bool
 )
 
+func defaultCacheDir() string {
+	if dir := os.Getenv("XDG_CACHE_HOME"); dir != "" {
+		return filepath.Join(dir, "testchart")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return filepath.Join(home, ".cache", "testchart")
+}
+
 func main() {
 	var testPath string
 	var namespace string
@@ -35,6 +47,7 @@ func main() {
 	var chartVersion string
 	var appVersion string
 	var concurrency int
+	var cacheDir string
 	isUpdate := false
 	var ignorePatterns []string
 
@@ -55,13 +68,14 @@ func main() {
 	rootCmd.PersistentFlags().StringVar(&debugOutput, "debug", "", "location to render failed install output manifests for debugging")
 	rootCmd.PersistentFlags().IntVarP(&concurrency, "concurrency", "c", runtime.GOMAXPROCS(0), "test run concurrency")
 	rootCmd.PersistentFlags().BoolVar(&normalize, "normalize", true, "normalize output. Disabling allows you to view raw helm templating.")
+	rootCmd.PersistentFlags().StringVar(&cacheDir, "cache-dir", defaultCacheDir(), "directory for caching downloaded schemas (set to empty string to disable)")
 
 	runCmd := &cobra.Command{
 		Use:   "run [test1 test2 ...]",
 		Short: "Run unit tests",
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runTests(args, testPath, namespace, release, chartVersion, appVersion, isUpdate, ignorePatterns, concurrency)
+			return runTests(args, testPath, namespace, release, chartVersion, appVersion, isUpdate, ignorePatterns, concurrency, cacheDir)
 		},
 	}
 
@@ -71,7 +85,7 @@ func main() {
 		Args:  cobra.ArbitraryArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			isUpdate = true
-			return runTests(args, testPath, namespace, release, chartVersion, appVersion, isUpdate, ignorePatterns, concurrency)
+			return runTests(args, testPath, namespace, release, chartVersion, appVersion, isUpdate, ignorePatterns, concurrency, cacheDir)
 		},
 	}
 
@@ -93,7 +107,7 @@ func main() {
 	}
 }
 
-func runTests(args []string, testPath, namespace, releaseName, chartVersion, appVersion string, isUpdate bool, ignorePatterns []string, concurrency int) error {
+func runTests(args []string, testPath, namespace, releaseName, chartVersion, appVersion string, isUpdate bool, ignorePatterns []string, concurrency int, cacheDir string) error {
 	if _, err := os.Stat(testPath); os.IsNotExist(err) {
 		fmt.Println("No tests found")
 		return nil
@@ -127,6 +141,7 @@ func runTests(args []string, testPath, namespace, releaseName, chartVersion, app
 		IgnorePatterns: ignorePatterns,
 		Schema:         schema,
 		Concurrency:    concurrency,
+		CacheDir:       cacheDir,
 		HelmOptions: HelmOptions{
 			Namespace:    namespace,
 			Release:      releaseName,
@@ -196,8 +211,13 @@ func loadValuesFile(filePath string) (map[string]any, error) {
 	return data, nil
 }
 
-func validateManifest(test *Test, manifest string) error {
-	v, err := validator.New(nil, validator.Opts{Strict: true, IgnoreMissingSchemas: true})
+func validateManifest(test *Test, manifest string, cacheDir string) error {
+	if cacheDir != "" {
+		if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+			return fmt.Errorf("creating cache directory: %w", err)
+		}
+	}
+	v, err := validator.New(nil, validator.Opts{Strict: true, IgnoreMissingSchemas: true, Cache: cacheDir})
 	if err != nil {
 		return fmt.Errorf("initializing validator: %w", err)
 	}


### PR DESCRIPTION
## What

Adds a `--cache-dir` flag that persists downloaded Kubernetes JSON schemas to disk between runs.

## Why

By default, testchart downloads schemas from `raw.githubusercontent.com` on every run. This creates an unnecessary network round-trip on each invocation and makes runs sensitive to network availability and rate limits.

`--cache-dir` addresses this by persisting schemas locally. After a warm cache, schema validation adds only a few milliseconds.

## How

- `--cache-dir` defaults to `$XDG_CACHE_HOME/testchart` (or `~/.cache/testchart`). Set to an empty string to disable caching entirely.
- The cache directory is created automatically on first use.
- The flag is passed through to `validator.Opts.Cache` (kubeconform's built-in on-disk cache).

## Performance

Benchmarked against a Helm chart with 100 tests using [hyperfine](https://github.com/sharkdp/hyperfine) (5 runs, 1 warmup):

|                      | Mean   | σ       |
| -------------------- | ------ | ------- |
| no cache (master)    | 9.40 s | ±0.42 s |
| warm cache (this PR) | 5.25 s | ±0.11 s |

**1.8× faster** on a warm cache. The tighter σ is a side effect too — removing the network hop makes runs more deterministic.
